### PR TITLE
removing kaggle depedency on running model notebook

### DIFF
--- a/model/build/README.md
+++ b/model/build/README.md
@@ -1,11 +1,3 @@
-# Prerequisites
-Create a kaggle account, and download an API key
-
-
-# Build Instructions
-
-If you run this on kaggle, you'll likely run out of credits after a few runs
-
 # Local build
 ```
 ./run_notebook.sh

--- a/model/build/docker-compose.yaml
+++ b/model/build/docker-compose.yaml
@@ -15,21 +15,19 @@ services:
   #         devices:
   #           - capabilities: [gpu]
 
-  dltacodataset:
-    image: kaggledl
+  tacodataset:
+    image: alpine
     volumes:
-      - ${HOME}/.kaggle:/home/kaggle/.kaggle
-      - ${PWD}:/home/kaggle/download
-    working_dir: /home/kaggle/download
-    command: kaggle datasets download -d kneroma/tacotrashdataset
+      - ${PWD}:/download
+    working_dir: /download
+    command: wget https://trash-ai-public.s3.us-west-1.amazonaws.com/tacotrashdataset.zip
 
-  dlyolov5-taco:
-    image: kaggledl
+  yolov5-taco:
+    image: alpine
     volumes:
-      - ${HOME}/.kaggle:/home/kaggle/.kaggle
-      - ${PWD}:/home/kaggle/download
-    working_dir: /home/kaggle/download
-    command: kaggle datasets download -d trngvhong/yolov5-taco
+      - ${PWD}:/download
+    working_dir: /download
+    command: wget https://trash-ai-public.s3.us-west-1.amazonaws.com/yolov5-taco.zip
 
   notebook:
     image: jupyter/datascience-notebook:b418b67c225b

--- a/model/build/run_notebook.sh
+++ b/model/build/run_notebook.sh
@@ -2,12 +2,5 @@
 set -euo pipefail
 IFS=$'\n\t'
 
-mkdir -p ~/.kaggle
-test -f ~/.kaggle/kaggle.json || {
-    echo "Kaggle API key not found. Please login and download api key and put it in ~/.kaggle/kaggle.json"
-    exit 1
-}
-chmod 600 ~/.kaggle/kaggle.json
-
 docker-compose up --build
 ./name_map.py


### PR DESCRIPTION
Removing a depedency on Kaggle by using s3 to download the necessary files rather than kaggle.