### PR TITLE
127 feature docker compose only deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ delete.bat
 .Rhistory
 model/build/Mask*
 model/build/taco*
+tags

--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -1,0 +1,34 @@
+# Include any files or directories that you don't want to be copied to your
+# container here (e.g., local build artifacts, temporary files, etc.).
+#
+# For more help, visit the .dockerignore file reference guide at
+# https://docs.docker.com/engine/reference/builder/#dockerignore-file
+
+**/.DS_Store
+**/__pycache__
+**/.venv
+**/.classpath
+**/.dockerignore
+**/.env
+**/.git
+**/.gitignore
+**/.project
+**/.settings
+**/.toolstarget
+**/.vs
+**/.vscode
+**/*.*proj.user
+**/*.dbmdl
+**/*.jfm
+**/bin
+**/charts
+**/docker-compose*
+**/compose*
+**/Dockerfile*
+**/node_modules
+**/npm-debug.log
+**/obj
+**/secrets.dev.yaml
+**/values.dev.yaml
+LICENSE
+README.md

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -30,5 +30,3 @@ EXPOSE 80
 # Start Nginx
 CMD ["nginx", "-g", "daemon off;"]
 
-# This Dockerfile starts with the official Node.js 14 Alpine image as the base image. It sets the working directory to `/app`, copies the `package.json` and `yarn.lock` files to the container, and installs the dependencies using Yarn.
-# Next, it copies the rest of the application code to the container and builds the application using Vite. It exposes port 3000 for the application and starts the application using the production build.

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,34 @@
+# Dockerfile for trash-ai frontend
+
+# Stage 1: Build the project
+FROM node:16.12.0 as builder
+
+# Set the working directory
+WORKDIR /app
+
+# Copy the package.json and yarn.lock files
+COPY package.json yarn.lock ./
+
+# Install dependencies
+RUN yarn install
+
+# Copy the rest of the project files
+COPY . .
+
+# Build the project
+RUN yarn build
+
+# Stage 2: Serve the built project with Nginx
+FROM nginx:1.23.3
+
+# Copy the built project from the previous stage
+COPY --from=builder /app/dist /usr/share/nginx/html
+
+# Expose port 80
+EXPOSE 80
+
+# Start Nginx
+CMD ["nginx", "-g", "daemon off;"]
+
+# This Dockerfile starts with the official Node.js 14 Alpine image as the base image. It sets the working directory to `/app`, copies the `package.json` and `yarn.lock` files to the container, and installs the dependencies using Yarn.
+# Next, it copies the rest of the application code to the container and builds the application using Vite. It exposes port 3000 for the application and starts the application using the production build.

--- a/frontend/docker-compose.yml
+++ b/frontend/docker-compose.yml
@@ -1,0 +1,6 @@
+version: '3'
+services:
+  frontend:
+    build: .
+    ports:
+      - "8080:80"


### PR DESCRIPTION

## Changes
1.  add Dockerfile file for frontend
2. add docker-compose.yml file for frontend
3. add .dockerignore file for frontend
4. Ignore tags

## Purpose
Fix #127 [Feature] docker compose only deployment

## Approach
1. `cd frontend`
2. `docker compose up`

## Learning
1. https://docs.docker.com/engine/reference/builder/
2. https://docs.docker.com/compose/compose-file/build/
3. https://docs.docker.com/engine/reference/builder/#dockerignore-file

## Pre-Testing
Start the docker daemon or docker desk on local

## Testing
After above `docker compose up` command, you should be able to access frontend app through browser by URL:
### `http://localhost:8080`
