### PR TITLE
Consistent csv delimiter

### DIFF
--- a/frontend/babel.config.js
+++ b/frontend/babel.config.js
@@ -1,3 +1,3 @@
 module.exports = {
-    presets: ['@vue/cli-plugin-babel/preset'],
+    presets: ['@vue/cli-plugin-babel/preset', '@babel/preset-typescript'],
 }

--- a/frontend/jest.config.js
+++ b/frontend/jest.config.js
@@ -1,5 +1,6 @@
 /** @type {import('ts-jest').JestConfigWithTsJest} */
 module.exports = {
-  preset: 'ts-jest',
-  testEnvironment: 'node',
-};
+    preset: 'ts-jest',
+    testEnvironment: 'node',
+    testMatch: ['**/*.spec.ts'],
+}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -44,6 +44,7 @@
         "webfontloader": "^1.6.28"
     },
     "devDependencies": {
+        "@babel/preset-typescript": "^7.22.5",
         "@types/crypto-js": "^4.1.1",
         "@types/file-saver": "^2.0.5",
         "@types/google.maps": "^3.49.2",

--- a/frontend/src/lib/csv/csv.ts
+++ b/frontend/src/lib/csv/csv.ts
@@ -5,11 +5,18 @@ import {
 } from './schema-parser'
 import { MapJsonProperties } from './types'
 
+type Column = string | number | boolean
+
+const quote = (s: string) => `"${s}"`
+const constructDelimetedRow = (delimeter: string) => (row: Column[]) =>
+    row.map((c) => (typeof c === 'string' ? quote(c) : c)).join(delimeter)
+const addNewlines = (s: Column[]) => s.join('\n')
+
 export const objectToCsv =
     <T>(
         headers: string[],
-        fnFlatten: (obj: T) => (string | number | boolean)[][],
-        joinStr: string = ',',
+        fnFlatten: (obj: T) => Column[][],
+        delimeter: string = ',',
     ) =>
     (obj: T) => {
         const csvData = fnFlatten(obj)
@@ -21,7 +28,11 @@ export const objectToCsv =
                 )}, see incorrect rows: ${JSON.stringify(errorRows)}`,
             )
         }
-        return [headers, ...csvData].map((row) => row.join(joinStr)).join('\n')
+        const rowsWithHeaders = [headers, ...csvData]
+        const delimetedRows = rowsWithHeaders.map(
+            constructDelimetedRow(delimeter),
+        )
+        return addNewlines(delimetedRows)
     }
 
 /**

--- a/frontend/src/lib/csv/schema-parser.spec.ts
+++ b/frontend/src/lib/csv/schema-parser.spec.ts
@@ -73,11 +73,11 @@ describe('csv', () => {
             ]),
         )(obj)
         expect(csv).toEqual(
-            'id,fruit,cultivar,inSeason\n' +
-                '1,apple,gala,false\n' +
-                '1,apple,red delicious,true\n' +
-                '1,pear,bosc,false\n' +
-                '1,pear,bartlett,true',
+            '"id","fruit","cultivar","inSeason"\n' +
+                '1,"apple","gala",false\n' +
+                '1,"apple","red delicious",true\n' +
+                '1,"pear","bosc",false\n' +
+                '1,"pear","bartlett",true',
         )
     })
 

--- a/frontend/src/lib/store/images.ts
+++ b/frontend/src/lib/store/images.ts
@@ -312,7 +312,7 @@ export const useImageStore = defineStore<
             const zname = `${bname}.zip`
             const folder = zip.folder(bname)
 
-            generateSummaryFiles(this.summary).map(([fileName, data]) =>
+            generateSummaryFiles(this.summary).map(({fileName, data}) =>
                 folder!.file(fileName, data),
             )
 
@@ -371,46 +371,44 @@ export const useImageStore = defineStore<
     },
 })
 
+// summary totals csv
+const sTotalsHeaders = ['total_detections', 'unique_detections']
+const summaryTotalsToCsv = objectToCsv(sTotalsHeaders, (o: Summary) => [
+    [o.total_detections, o.unique_detections],
+])
+
+// summary detected objects csv
+const detectedHeaders = getCsvHeadersFromJsonSchema(
+    summarySchema.properties.detected_objects as JSONSchema7,
+)
+const detectedToCsv = objectToCsv(detectedHeaders, (obj: Summary) =>
+    obj.detected_objects.map((v) => [v.name, v.count, v.hashes.join(',')]),
+)
+
+// summary gps objects csv
+const gpsHeaders = getCsvHeadersFromJsonSchema(
+    summarySchema.properties.gps.properties.list.items as JSONSchema7,
+)
+const gpsToCsv = objectToCsv(gpsHeaders, (obj: Summary) =>
+    obj.gps.list.map((v) => [
+        v?.coordinate?.lat ?? '',
+        v?.coordinate?.lng ?? '',
+        v.hash,
+    ]),
+)
+
 const generateSummaryFiles = (summary: Summary) => {
-    const files: [string, string][] = []
-    // summary json
-    files.push(['summary.json', JSON.stringify(summary)])
+    const filesToGenerate = [
+        { fileName: 'summary.json', dataFn: JSON.stringify },
+        { fileName: 'summary_totals.csv', dataFn: summaryTotalsToCsv },
+        { fileName: 'summary_detected.csv', dataFn: detectedToCsv },
+        ...(summary.gps.list.length > 0
+            ? [{ fileName: 'summary_gps.csv', dataFn: gpsToCsv }]
+            : []),
+    ]
 
-    // summary totals csv
-    const sTotalsHeaders = ['total_detections', 'unique_detections']
-    const summaryTotalsCsv = objectToCsv(sTotalsHeaders, (o: Summary) => [
-        [o.total_detections, o.unique_detections],
-    ])(summary)
-    files.push(['summary_totals.csv', summaryTotalsCsv])
-
-    // summary detected objects csv
-    const detectedHeaders = getCsvHeadersFromJsonSchema(
-        summarySchema.properties.detected_objects as JSONSchema7,
-    )
-    const detectedCsv = objectToCsv(
-        detectedHeaders,
-        (obj: Summary) =>
-            obj.detected_objects.map((v) => [
-                v.name,
-                v.count,
-                v.hashes.join(','),
-            ]),
-    )(summary)
-    files.push(['summary_detected.csv', detectedCsv])
-
-    // summary gps objects csv
-    if (summary.gps.list.length > 0) {
-        const gpsHeaders = getCsvHeadersFromJsonSchema(
-            summarySchema.properties.gps.properties.list.items as JSONSchema7,
-        )
-        const gpsCsv = objectToCsv(gpsHeaders, (obj: Summary) =>
-            obj.gps.list.map((v) => [
-                v?.coordinate?.lat ?? '',
-                v?.coordinate?.lng ?? '',
-                v.hash,
-            ]),
-        )(summary)
-        files.push(['summary_gps.csv', gpsCsv])
-    }
-    return files
+    return filesToGenerate.map(({ fileName, dataFn }) => ({
+        fileName,
+        data: dataFn(summary),
+    }))
 }

--- a/frontend/src/lib/store/images.ts
+++ b/frontend/src/lib/store/images.ts
@@ -395,7 +395,6 @@ const generateSummaryFiles = (summary: Summary) => {
                 v.count,
                 v.hashes.join(','),
             ]),
-        ';',
     )(summary)
     files.push(['summary_detected.csv', detectedCsv])
 

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -566,7 +566,7 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.14.5"
 
-"@babel/plugin-syntax-typescript@^7.7.2":
+"@babel/plugin-syntax-typescript@^7.22.5", "@babel/plugin-syntax-typescript@^7.7.2":
   version "7.22.5"
   resolved "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.22.5.tgz"
   integrity sha512-1mS2o03i7t1c6VzH6fdQ3OA8tcEIxwG18zIPRp+UY1Ihv6W+XZzBCVxExF9upussPXJ0xE9XRHwMoNs1ep/nRQ==
@@ -950,6 +950,16 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.22.5"
 
+"@babel/plugin-transform-typescript@^7.22.5":
+  version "7.22.5"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.22.5.tgz#5c0f7adfc1b5f38c4dbc8f79b1f0f8074134bd7d"
+  integrity sha512-SMubA9S7Cb5sGSFFUlqxyClTA9zWJ8qGQrppNUm05LtFuN1ELRFNndkix4zUJrC9F+YivWwa1dHMSyo0e0N9dA==
+  dependencies:
+    "@babel/helper-annotate-as-pure" "^7.22.5"
+    "@babel/helper-create-class-features-plugin" "^7.22.5"
+    "@babel/helper-plugin-utils" "^7.22.5"
+    "@babel/plugin-syntax-typescript" "^7.22.5"
+
 "@babel/plugin-transform-unicode-escapes@^7.22.5":
   version "7.22.5"
   resolved "https://registry.npmjs.org/@babel/plugin-transform-unicode-escapes/-/plugin-transform-unicode-escapes-7.22.5.tgz"
@@ -1077,6 +1087,17 @@
     "@babel/plugin-transform-dotall-regex" "^7.4.4"
     "@babel/types" "^7.4.4"
     esutils "^2.0.2"
+
+"@babel/preset-typescript@^7.22.5":
+  version "7.22.5"
+  resolved "https://registry.yarnpkg.com/@babel/preset-typescript/-/preset-typescript-7.22.5.tgz#16367d8b01d640e9a507577ed4ee54e0101e51c8"
+  integrity sha512-YbPaal9LxztSGhmndR46FmAbkJ/1fAsw293tSU+I5E5h+cnJ3d4GTwyUgGYmOXJYdGA+uNePle4qbaRzj2NISQ==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.22.5"
+    "@babel/helper-validator-option" "^7.22.5"
+    "@babel/plugin-syntax-jsx" "^7.22.5"
+    "@babel/plugin-transform-modules-commonjs" "^7.22.5"
+    "@babel/plugin-transform-typescript" "^7.22.5"
 
 "@babel/regjsgen@^0.8.0":
   version "0.8.0"


### PR DESCRIPTION
## Changes
1. Only using comma to delimit csv summary files
2. Automatically quoting all string fields in csv file

## Purpose
Csv files contained inconsistent delimiters, this makes them all use comma

## Approach
Some specific columns in the csv are themselves comma separated, hence the difference in delimeter.  However this is not an issue if we instead quote the field properly.  This approach now quotes all string fields, which should be safer and more consistent in the long run in case there are other use cases added to generate csv files.

## Testing

1. Show samples or upload files
2. Download all files
3. Inspect the summary*.csv files
