### PR TITLE
Fixing Dan Fey author name

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -6,7 +6,7 @@ authors:
 - family-names: Hollingsworth
   given-names: Steven
 - family-names: Fey
-  given-names: Day
+  given-names: Dan
 - family-names: Norris
   given-names: Mary C
 - family-names: Yu


### PR DESCRIPTION
Dan Fey was spelled wrong.  This MR corrects it
